### PR TITLE
feat: multi-user support with named profiles and get_project_members tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,8 +88,8 @@ To avoid conflicts with other projects' environment variables, redmine-mcp uses 
   - `REDMINE_MCP_TIMEOUT`: Request timeout (seconds)
   - `REDMINE_TIMEOUT`: Backward-compatible timeout setting
 
-### Available MCP Tools (26)
-- **Management Tools**: server_info, health_check, refresh_cache
+### Available MCP Tools (29)
+- **Management Tools**: server_info, health_check, refresh_cache, list_user_profiles, set_current_user, get_current_user
 - **Query Tools**: get_issue, list_project_issues, get_projects, get_issue_statuses, get_trackers, get_priorities, get_time_entry_activities, get_document_categories, search_issues, get_my_issues
 - **Journal Tools**: list_issue_journals, get_journal
 - **Attachment Tools**: get_attachment_info, get_attachment_image ✨ New (supports thumbnail and visual analysis)
@@ -119,13 +119,47 @@ uv run python -m pytest tests/
 uv add <package-name>
 ```
 
+## Multi-User Support ✨
+
+### Named User Profiles
+The server supports multiple Redmine users via named profiles stored in `~/.redmine_mcp/users.json`:
+
+```json
+{
+  "alice": {"api_key": "alice_key", "description": "Project Manager"},
+  "bob": {"api_key": "bob_key", "description": "Developer"}
+}
+```
+
+**Recommended workflow** — set the current user once per session:
+```python
+set_current_user(profile_name="alice")
+get_issue(123)
+create_new_issue(project_id=1, subject="Bug")
+```
+
+All tools also accept an explicit `profile_name` for one-off calls:
+```python
+get_issue(123, profile_name="alice")
+create_new_issue(project_id=1, subject="Bug", profile_name="bob")
+```
+
+When `profile_name` is omitted and no default user is set, the `REDMINE_API_KEY` from `.env` is used.
+Each profile gets an isolated client with its own cache file.
+
+Environment variable for default profile:
+```env
+REDMINE_DEFAULT_PROFILE=alice
+```
+
 ## Smart Cache System ✨
 
 ### Cache Mechanism Features
 - **Multi-Domain Support**: Automatically creates independent cache files based on Redmine domain
+- **Multi-User Support**: Each profile gets isolated cache files based on API key
 - **Auto-Update**: Cache data automatically refreshes every 24 hours
 - **Full Coverage**: Caches enum values (priority, status, tracker) and user data
-- **File Location**: `~/.redmine_mcp/cache_{domain}_{hash}.json`
+- **File Location**: `~/.redmine_mcp/cache_{domain}_{hash}_{key_hash}.json`
 
 ### Available Helper Functions
 ```python
@@ -155,6 +189,7 @@ client.refresh_cache()
 
 ### MCP Tools
 - `refresh_cache()`: Manually refresh cache and display statistics
+- `list_user_profiles()`: List available MCP user profiles configured on this server
 
 ## Name Parameter Support ✨
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,9 @@ ENV REDMINE_MCP_TRANSPORT=sse
 ENV REDMINE_MCP_HOST=0.0.0.0
 ENV REDMINE_MCP_PORT=8000
 
+# Create config directory for user profiles
+RUN mkdir -p /home/mcp/.redmine_mcp && chown -R mcp:mcp /home/mcp/.redmine_mcp
+
 # Switch to non-root user
 USER mcp
 

--- a/README.md
+++ b/README.md
@@ -93,15 +93,114 @@ LOG_LEVEL=info
 
 > **Note**: The system automatically handles case conversion and ensures FastMCP compatibility.
 
-### 4. Redmine API Setup
+### 4. Multi-User Support (Optional)
 
-#### 4.1 Enable REST API
+The server supports named user profiles, allowing multiple agents/users to operate as different Redmine identities within a single MCP configuration.
+
+#### 4.1 Create User Profiles File
+
+Create `~/.redmine_mcp/users.json`:
+
+```json
+{
+  "alice": {
+    "api_key": "alice_redmine_api_key",
+    "description": "Project Manager"
+  },
+  "bob": {
+    "api_key": "bob_redmine_api_key",
+    "description": "Developer"
+  }
+}
+```
+
+Or use the simple string format:
+```json
+{
+  "alice": "alice_redmine_api_key",
+  "bob": "bob_redmine_api_key"
+}
+```
+
+#### 4.2 Using Profiles
+
+All MCP tools accept an optional `profile_name` parameter:
+
+```python
+# Act as alice
+get_issue(123, profile_name="alice")
+
+# Act as bob
+create_new_issue(project_id=1, subject="Bug fix", profile_name="bob")
+```
+
+If `profile_name` is omitted, the default `REDMINE_API_KEY` from `.env` is used.
+
+Use `list_user_profiles()` to see available profiles.
+
+> **Security Note**: Raw API keys are never exposed in tool arguments. Only pre-configured profile names are passed.
+
+#### Setting a Default User (Recommended)
+
+Instead of passing `profile_name` on every call, set a default user once per session:
+
+```python
+# 1. List available profiles
+list_user_profiles()
+
+# 2. Set yourself as the current user
+set_current_user(profile_name="Семён Слепоков")
+
+# 3. Now all calls use Семён's API key automatically
+get_issue(123)
+add_issue_note(issue_id=123, notes="Done")
+create_new_issue(project_id=1, subject="New task")
+
+# 4. Override for a single call if needed
+get_issue(456, profile_name="Валентина Петрова")
+
+# 5. Clear the default
+set_current_user(profile_name="")
+```
+
+You can also set a default profile via environment variable:
+```env
+REDMINE_DEFAULT_PROFILE=Семён Слепоков
+```
+
+> **Important for SSE mode**: `set_current_user` sets the default for the entire server process. If multiple agents connect to the same SSE server, they share the same default. For isolated sessions use stdio mode or run separate containers per user.
+
+#### Docker / Docker Compose
+
+When running in a container, mount the `users.json` file:
+
+```bash
+# Docker run
+docker run -d \
+  -e REDMINE_DOMAIN=https://your-redmine.com \
+  -e REDMINE_API_KEY=your_api_key \
+  -v $(pwd)/users.json:/home/mcp/.redmine_mcp/users.json:ro \
+  -p 8000:8000 \
+  --name redmine-mcp \
+  redmine-mcp
+```
+
+For Docker Compose, the `docker-compose.yml` already includes the volume mount. Just create `users.json` next to `docker-compose.yml`:
+
+```bash
+echo '{"alice": "alice_api_key", "bob": "bob_api_key"}' > users.json
+docker compose up -d
+```
+
+### 5. Redmine API Setup
+
+#### 5.1 Enable REST API
 1. Log in to Redmine as administrator
 2. Go to **Administration** → **Settings** → **API**
 3. Check **"Enable REST web service"**
 4. Click **Save**
 
-#### 4.2 Configure Redmine Basic Data (Administrator)
+#### 5.2 Configure Redmine Basic Data (Administrator)
 Before using MCP tools, you need to configure Redmine's basic data:
 
 **Configure Roles and Permissions**
@@ -130,7 +229,7 @@ Before using MCP tools, you need to configure Redmine's basic data:
 3. Select enabled modules (at least enable "Issue tracking")
 4. Assign members and set roles
 
-#### 4.3 Get API Key
+#### 5.3 Get API Key
 1. Log in to your Redmine system (can be administrator or regular user)
 2. Go to **My account** → **API access key**
 3. Click **Show** or **Reset** to get the API key
@@ -141,6 +240,44 @@ Before using MCP tools, you need to configure Redmine's basic data:
 > - Complete basic setup before you can properly create and manage issues
 > 
 > **📚 Detailed Setup Guide**: For complete Redmine setup steps, please refer to [Redmine Complete Setup Guide](docs/manuals/redmine_setup_guide.md)
+
+## 💬 Usage Examples in Chat
+
+### Acting as a Specific User
+
+**Recommended approach**: set the current user once, then work normally.
+
+```python
+# 1. List available profiles
+list_user_profiles()
+# → Available user profiles:
+#   - alice - Project Manager
+#   - bob - Developer
+
+# 2. Set yourself as the current user (one time per session)
+set_current_user(profile_name="alice")
+
+# 3. All subsequent calls automatically use alice's API key
+get_issue(123)
+create_new_issue(project_id=1, subject="[Bug] Login error")
+update_issue_status(issue_id=123, status_name="Resolved")
+get_my_issues(status_filter="open")
+
+# 4. Override for a single call if needed
+get_issue(456, profile_name="bob")
+
+# 5. Clear when done
+set_current_user(profile_name="")
+```
+
+**Alternative**: pass `profile_name` explicitly on every call (useful for one-off actions):
+
+```python
+get_issue(123, profile_name="alice")
+add_issue_note(issue_id=123, notes="Done", profile_name="bob")
+```
+
+> **Note**: `set_current_user` stores the default in the server's memory. In SSE mode with multiple agents sharing one server, they share the same default. For fully isolated sessions, use stdio mode or run separate containers.
 
 ## 🔗 Claude Code Integration
 
@@ -250,6 +387,25 @@ docker compose logs -f
 
 # Stop the service
 docker compose down
+```
+
+#### Docker with Multi-User Profiles
+
+```yaml
+# docker-compose.yml
+services:
+  redmine-mcp:
+    build: .
+    container_name: redmine-mcp
+    ports:
+      - "8000:8000"
+    environment:
+      - REDMINE_DOMAIN=${REDMINE_DOMAIN}
+      - REDMINE_API_KEY=${REDMINE_API_KEY}
+    volumes:
+      - ./users.json:/home/mcp/.redmine_mcp/users.json:ro
+    restart: unless-stopped
+```
 ```
 
 #### Docker Compose with .env file (Recommended)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       - REDMINE_MCP_HOST=0.0.0.0
       - REDMINE_MCP_LOG_LEVEL=INFO
       - REDMINE_MCP_TIMEOUT=30
+    volumes:
+      # Mount user profiles file (optional, for multi-user support)
+      - ./users.json:/home/mcp/.redmine_mcp/users.json:ro
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8000/sse", "--max-time", "5"]

--- a/src/redmine_mcp/config.py
+++ b/src/redmine_mcp/config.py
@@ -3,8 +3,10 @@ Configuration management module
 Responsible for loading and validating environment variable configurations
 """
 
+import json
 import os
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Dict, Any
 from dotenv import load_dotenv
 
 
@@ -18,6 +20,11 @@ class RedmineConfig:
         # Required configuration
         self.redmine_domain = self._get_required_env("REDMINE_DOMAIN")
         self.redmine_api_key = self._get_required_env("REDMINE_API_KEY")
+
+        # User profiles configuration
+        self._users_file_path = Path.home() / ".redmine_mcp" / "users.json"
+        self._user_profiles: Optional[Dict[str, Dict[str, Any]]] = None
+        self._default_profile_name: Optional[str] = os.getenv("REDMINE_DEFAULT_PROFILE") or None
 
         # Optional configuration - use dedicated prefix to avoid conflicts with other projects
         self.redmine_timeout = int(os.getenv("REDMINE_MCP_TIMEOUT") or os.getenv("REDMINE_TIMEOUT") or "30")
@@ -59,6 +66,69 @@ class RedmineConfig:
         if not value:
             raise ValueError(f"Required environment variable {key} is not set")
         return value
+
+    def _load_user_profiles(self) -> Dict[str, Dict[str, Any]]:
+        """Load user profiles from the configuration file"""
+        if self._user_profiles is not None:
+            return self._user_profiles
+
+        if not self._users_file_path.exists():
+            self._user_profiles = {}
+            return self._user_profiles
+
+        try:
+            with open(self._users_file_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            # Normalize to dict of dicts
+            profiles: Dict[str, Dict[str, Any]] = {}
+            for name, value in data.items():
+                if isinstance(value, dict) and 'api_key' in value:
+                    profiles[name] = {
+                        'api_key': value['api_key'],
+                        'description': value.get('description', '')
+                    }
+                elif isinstance(value, str):
+                    # Simple string mapping: name -> api_key
+                    profiles[name] = {'api_key': value, 'description': ''}
+            self._user_profiles = profiles
+        except (json.JSONDecodeError, OSError):
+            self._user_profiles = {}
+
+        return self._user_profiles
+
+    def get_user_api_key(self, user_name: str) -> Optional[str]:
+        """Get API key for a named user profile"""
+        profiles = self._load_user_profiles()
+        profile = profiles.get(user_name)
+        if profile:
+            return profile.get('api_key')
+        return None
+
+    def list_user_profiles(self) -> Dict[str, str]:
+        """List available user profiles (name -> description, excluding API keys)"""
+        profiles = self._load_user_profiles()
+        return {
+            name: profile.get('description', '')
+            for name, profile in profiles.items()
+        }
+
+    def refresh_user_profiles(self) -> None:
+        """Force reload user profiles from disk"""
+        self._user_profiles = None
+
+    @property
+    def default_profile_name(self) -> Optional[str]:
+        """Return the current default profile name (from env or set_current_user)"""
+        return self._default_profile_name
+
+    def set_default_profile(self, profile_name: Optional[str]) -> None:
+        """Set the default profile name for this server instance"""
+        self._default_profile_name = profile_name
+
+    @property
+    def users_file_path(self) -> Path:
+        """Return the path to the user profiles file"""
+        return self._users_file_path
 
     def _validate_config(self) -> None:
         """Validate configuration values"""

--- a/src/redmine_mcp/redmine_client.py
+++ b/src/redmine_mcp/redmine_client.py
@@ -68,20 +68,25 @@ class RedmineAPIError(Exception):
 class RedmineClient:
     """Redmine API client"""
     
-    def __init__(self):
+    def __init__(self, api_key: Optional[str] = None):
         self.config = get_config()
+        self.api_key = api_key or self.config.redmine_api_key
         self.session = requests.Session()
         self.session.headers.update(self.config.api_headers)
+        # Override API key if a custom one is provided
+        if api_key:
+            self.session.headers['X-Redmine-API-Key'] = api_key
         self.session.timeout = self.config.redmine_timeout
         
         # Cache-related settings
         self.cache_dir = Path.home() / ".redmine_mcp"
         self.cache_dir.mkdir(exist_ok=True)
         
-        # Create a unique cache file name based on domain
+        # Create a unique cache file name based on domain and API key
         domain_hash = hash(self.config.redmine_domain)
         safe_domain = self.config.redmine_domain.replace('://', '_').replace('/', '_').replace(':', '_')
-        self._cache_file = self.cache_dir / f"cache_{safe_domain}_{abs(domain_hash)}.json"
+        key_hash = hash(self.api_key)
+        self._cache_file = self.cache_dir / f"cache_{safe_domain}_{abs(domain_hash)}_{abs(key_hash)}.json"
         self._enum_cache: Optional[Dict[str, Any]] = None
         self._category_cache: Dict[int, Dict[str, int]] = {}  # {project_id: {name: id}}
         self._issue_snapshots: Dict[int, Dict[str, Any]] = {}  # {issue_id: snapshot}
@@ -880,20 +885,21 @@ class RedmineClient:
             raise RedmineAPIError(f"Failed to download attachment: {str(e)}")
 
 
-# Global client instance
-_client: Optional[RedmineClient] = None
+# Global client registry: api_key -> RedmineClient
+_clients: Dict[str, RedmineClient] = {}
 
 
-def get_client() -> RedmineClient:
-    """Get global client instance (singleton pattern)"""
-    global _client
-    if _client is None:
-        _client = RedmineClient()
-    return _client
+def get_client(api_key: Optional[str] = None) -> RedmineClient:
+    """Get client instance for the given API key (cached per key)"""
+    global _clients
+    cache_key = api_key or "__default__"
+    if cache_key not in _clients:
+        _clients[cache_key] = RedmineClient(api_key=api_key)
+    return _clients[cache_key]
 
 
 def reload_client() -> RedmineClient:
-    """Reload client (mainly used for testing)"""
-    global _client
-    _client = None
+    """Reload all clients (mainly used for testing)"""
+    global _clients
+    _clients = {}
     return get_client()

--- a/src/redmine_mcp/redmine_client.py
+++ b/src/redmine_mcp/redmine_client.py
@@ -396,6 +396,16 @@ class RedmineClient:
         
         return projects
     
+    def get_project_members(self, project_id: Union[int, str], limit: int = 100, offset: int = 0) -> List[Dict[str, Any]]:
+        """Get project members (users with their roles).
+        
+        This endpoint does not require global 'View users' permission —
+        only project membership is needed.
+        """
+        params = {'limit': limit, 'offset': offset}
+        response = self._make_request('GET', f'/projects/{project_id}/memberships.json', params=params)
+        return response.get('memberships', [])
+    
     def create_project(self, name: str, identifier: str, description: str = "",
                       homepage: str = "", is_public: bool = True, parent_id: Optional[int] = None,
                       inherit_members: bool = False, tracker_ids: Optional[List[int]] = None,

--- a/src/redmine_mcp/server.py
+++ b/src/redmine_mcp/server.py
@@ -20,6 +20,86 @@ from .redmine_client import get_client, RedmineAPIError
 # Create FastMCP server instance
 mcp = FastMCP("Redmine MCP")
 
+def _resolve_user(profile_name: str = None) -> str:
+    """Resolve profile_name to an API key, or None for default.
+    Falls back to the configured default profile if no profile_name is given."""
+    config = get_config()
+    effective_profile = profile_name or config.default_profile_name
+    if not effective_profile:
+        return None
+    api_key = config.get_user_api_key(effective_profile)
+    if not api_key:
+        raise ValueError(f"User profile not found: '{effective_profile}'. Use list_user_profiles() to see available profiles.")
+    return api_key
+
+
+
+@mcp.tool()
+def list_user_profiles() -> str:
+    """List available MCP user profiles configured on this server"""
+    try:
+        config = get_config()
+        profiles = config.list_user_profiles()
+        if not profiles:
+            return "No user profiles configured. Create ~/.redmine_mcp/users.json to add profiles."
+        result = "Available user profiles:\n\n"
+        for name, desc in profiles.items():
+            marker = " (current default)" if name == config.default_profile_name else ""
+            desc_text = f" - {desc}" if desc else ""
+            result += f"- {name}{marker}{desc_text}\n"
+        if config.default_profile_name and config.default_profile_name not in profiles:
+            result += f"\nDefault profile '{config.default_profile_name}' is set but not found in profiles file."
+        return result
+    except Exception as e:
+        return f"Error listing profiles: {str(e)}"
+
+
+@mcp.tool()
+def set_current_user(profile_name: str = "") -> str:
+    """Set the default Redmine user for this session.
+
+    After calling this tool, all subsequent operations will use the specified
+    user's API key unless an explicit profile_name is provided.
+
+    Args:
+        profile_name: Profile name from list_user_profiles(). Pass empty string to clear.
+
+    Returns:
+        Confirmation message
+    """
+    try:
+        config = get_config()
+        if not profile_name:
+            config.set_default_profile(None)
+            return "Default user cleared. Subsequent calls will use the default API key from .env"
+
+        api_key = config.get_user_api_key(profile_name)
+        if not api_key:
+            profiles = config.list_user_profiles()
+            available = "\n".join([f"- {name}" for name in profiles.keys()]) or "(no profiles configured)"
+            return f"Profile not found: '{profile_name}'\n\nAvailable profiles:\n{available}"
+
+        config.set_default_profile(profile_name)
+        return f"Current user set to '{profile_name}'. All subsequent calls will use this profile by default."
+    except Exception as e:
+        return f"Error setting current user: {str(e)}"
+
+
+@mcp.tool()
+def get_current_user() -> str:
+    """Get the currently configured default Redmine user"""
+    try:
+        config = get_config()
+        profile = config.default_profile_name
+        if not profile:
+            return "No default user is set. Using the default API key from .env"
+        api_key = config.get_user_api_key(profile)
+        if not api_key:
+            return f"Default user is set to '{profile}', but this profile was not found in users.json"
+        return f"Current user: '{profile}'"
+    except Exception as e:
+        return f"Error getting current user: {str(e)}"
+
 
 @mcp.tool()
 def server_info() -> str:
@@ -32,11 +112,11 @@ def server_info() -> str:
 
 
 @mcp.tool()
-def health_check() -> str:
+def health_check(profile_name: str = None) -> str:
     """Health check tool to confirm that the server is functioning properly"""
     try:
         config = get_config()
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         # Test connection
         if client.test_connection():
             return f"✓ The server is functioning normally and connected to {config.redmine_domain}"
@@ -47,7 +127,7 @@ def health_check() -> str:
 
 
 @mcp.tool()
-def get_issue(issue_id: int, include_details: bool = True) -> str:
+def get_issue(issue_id: int, include_details: bool = True, profile_name: str = None) -> str:
     """
     Get specific Redmine issue details
     
@@ -59,7 +139,7 @@ def get_issue(issue_id: int, include_details: bool = True) -> str:
         Detailed information about the issue, presented in an easy-to-read format
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         include_params = []
         if include_details:
             include_params = ['attachments', 'changesets', 'children', 'journals', 'relations', 'watchers']
@@ -193,7 +273,7 @@ def get_issue(issue_id: int, include_details: bool = True) -> str:
 
 
 @mcp.tool()
-def update_issue_status(issue_id: int, status_id: int = None, status_name: str = None, notes: str = "") -> str:
+def update_issue_status(issue_id: int, status_id: int = None, status_name: str = None, notes: str = "", profile_name: str = None) -> str:
     """
     Update issue status
     
@@ -207,7 +287,7 @@ def update_issue_status(issue_id: int, status_id: int = None, status_name: str =
         Update result message
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         
         # Processing status parameters
         final_status_id = status_id
@@ -247,7 +327,7 @@ New status: {updated_issue.status.get('name', 'N/A')}"""
 
 
 @mcp.tool()
-def list_project_issues(project_id: int, status_filter: str = "open", limit: int = 20) -> str:
+def list_project_issues(project_id: int, status_filter: str = "open", limit: int = 20, profile_name: str = None) -> str:
     """
     List project topics
     
@@ -260,7 +340,7 @@ def list_project_issues(project_id: int, status_filter: str = "open", limit: int
         List of project issues, presented in table format
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         
         # limit limit range
         limit = min(max(limit, 1), 100)
@@ -317,7 +397,7 @@ Found {len(issues)} issues:
 
 
 @mcp.tool()
-def get_issue_statuses() -> str:
+def get_issue_statuses(profile_name: str = None) -> str:
     """
     Get a list of all available issue statuses
     
@@ -325,7 +405,7 @@ def get_issue_statuses() -> str:
         Formatted status list
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         statuses = client.get_issue_statuses()
         
         if not statuses:
@@ -348,7 +428,7 @@ def get_issue_statuses() -> str:
 
 
 @mcp.tool()
-def get_trackers() -> str:
+def get_trackers(profile_name: str = None) -> str:
     """
     Get a list of all available trackers
     
@@ -356,7 +436,7 @@ def get_trackers() -> str:
         Formatted tracker list
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         trackers = client.get_trackers()
         
         if not trackers:
@@ -379,7 +459,7 @@ def get_trackers() -> str:
 
 
 @mcp.tool()
-def get_priorities() -> str:
+def get_priorities(profile_name: str = None) -> str:
     """
     Get a priority list of all available issues
     
@@ -387,7 +467,7 @@ def get_priorities() -> str:
         Formatted priority list
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         priorities = client.get_priorities()
         
         if not priorities:
@@ -410,7 +490,7 @@ def get_priorities() -> str:
 
 
 @mcp.tool()
-def get_time_entry_activities() -> str:
+def get_time_entry_activities(profile_name: str = None) -> str:
     """
     Get a list of all available time tracking activities
     
@@ -418,7 +498,7 @@ def get_time_entry_activities() -> str:
         Formatted time tracking activity list
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         activities = client.get_time_entry_activities()
         
         if not activities:
@@ -441,7 +521,7 @@ def get_time_entry_activities() -> str:
 
 
 @mcp.tool()
-def get_document_categories() -> str:
+def get_document_categories(profile_name: str = None) -> str:
     """
     Get a list of all available file categories
     
@@ -449,7 +529,7 @@ def get_document_categories() -> str:
         Formatted file classification list
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         categories = client.get_document_categories()
         
         if not categories:
@@ -472,7 +552,7 @@ def get_document_categories() -> str:
 
 
 @mcp.tool()
-def get_issue_categories(project_id: int) -> str:
+def get_issue_categories(project_id: int, profile_name: str = None) -> str:
     """
     Obtain the issue classification list of the specified project
 
@@ -485,7 +565,7 @@ def get_issue_categories(project_id: int) -> str:
         Formatted issue category list
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         categories = client.get_issue_categories(project_id)
 
         if not categories:
@@ -507,7 +587,7 @@ def get_issue_categories(project_id: int) -> str:
 
 
 @mcp.tool()
-def get_projects() -> str:
+def get_projects(profile_name: str = None) -> str:
     """
     Get a list of accessible projects
     
@@ -515,7 +595,7 @@ def get_projects() -> str:
         Formatted project list
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         projects = client.list_projects(limit=50)
         
         if not projects:
@@ -539,7 +619,7 @@ def get_projects() -> str:
 
 
 @mcp.tool()
-def search_issues(query: str, project_id: int = None, limit: int = 10) -> str:
+def search_issues(query: str, project_id: int = None, limit: int = 10, profile_name: str = None) -> str:
     """
     Search for issues (search keywords in title or description)
     
@@ -555,7 +635,7 @@ def search_issues(query: str, project_id: int = None, limit: int = 10) -> str:
         if not query.strip():
             return "Please provide search keywords"
         
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         limit = min(max(limit, 1), 50)
         
         # Set search parameters
@@ -616,7 +696,7 @@ def update_issue_content(issue_id: int, subject: str = None, description: str = 
                         parent_issue_id: int = None, remove_parent: bool = False, start_date: str = None, due_date: str = None,
                         estimated_hours: float = None,
                         category_id: int = None, category_name: str = None,
-                        custom_fields: list[dict] = None) -> str:
+                        custom_fields: list[dict] = None, profile_name: str = None) -> str:
     """
     Update issue content (title, description, priority, completion, tracker, category, date, hours, custom fields, etc.)
 
@@ -642,7 +722,7 @@ def update_issue_content(issue_id: int, subject: str = None, description: str = 
         Update result message
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         
         # Prepare to update information
         update_data = {}
@@ -772,7 +852,7 @@ Current status:
 @mcp.tool()
 def add_issue_note(issue_id: int, notes: str, private: bool = False, 
                    spent_hours: float = None, activity_name: str = None, 
-                   activity_id: int = None, spent_on: str = None) -> str:
+                   activity_id: int = None, spent_on: str = None, profile_name: str = None) -> str:
     """
     Add notes to the topic and record the time at the same time
     
@@ -792,7 +872,7 @@ def add_issue_note(issue_id: int, notes: str, private: bool = False,
         if not notes.strip():
             return "Error: Note content cannot be empty"
         
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         time_entry_id = None
         
         # Processing time record
@@ -864,7 +944,7 @@ Time record added successfully!
 
 
 @mcp.tool()
-def assign_issue(issue_id: int, user_id: int = None, user_name: str = None, user_login: str = None, notes: str = "") -> str:
+def assign_issue(issue_id: int, user_id: int = None, user_name: str = None, user_login: str = None, notes: str = "", profile_name: str = None) -> str:
     """
     Assign issues to users
     
@@ -879,7 +959,7 @@ def assign_issue(issue_id: int, user_id: int = None, user_name: str = None, user
         Assignment result message
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         
         # Handle user parameters
         final_user_id = user_id
@@ -941,7 +1021,7 @@ def create_new_issue(project_id: int, subject: str, description: str = "",
                     assigned_to_id: int = None, assigned_to_name: str = None, assigned_to_login: str = None,
                     parent_issue_id: int = None, start_date: str = None, due_date: str = None,
                     estimated_hours: float = None, status_id: int = None, status_name: str = None,
-                    category_id: int = None, category_name: str = None) -> str:
+                    category_id: int = None, category_name: str = None, profile_name: str = None) -> str:
     """
     Create a new Redmine issue
 
@@ -979,7 +1059,7 @@ def create_new_issue(project_id: int, subject: str, description: str = "",
         if not subject.strip():
             return "Error: Issue title cannot be empty"
         
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         
         # Handling tracker parameters
         final_tracker_id = tracker_id
@@ -1087,7 +1167,7 @@ Assigned to: {new_issue.assigned_to.get('name', 'Not assigned') if new_issue.ass
 
 
 @mcp.tool()
-def get_my_issues(status_filter: str = "open", limit: int = 20) -> str:
+def get_my_issues(status_filter: str = "open", limit: int = 20, profile_name: str = None) -> str:
     """
     Get a list of issues assigned to me
     
@@ -1099,7 +1179,7 @@ def get_my_issues(status_filter: str = "open", limit: int = 20) -> str:
         My issue list
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         
         # Get current user information first
         current_user = client.get_current_user()
@@ -1153,7 +1233,7 @@ Found {len(issues)} issues:
 
 
 @mcp.tool()
-def close_issue(issue_id: int, notes: str = "", done_ratio: int = 100) -> str:
+def close_issue(issue_id: int, notes: str = "", done_ratio: int = 100, profile_name: str = None) -> str:
     """
     Close the issue (set to completed status)
     
@@ -1166,7 +1246,7 @@ def close_issue(issue_id: int, notes: str = "", done_ratio: int = 100) -> str:
         Close results message
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         
         # Get a list of available states and look for closed states
         statuses = client.get_issue_statuses()
@@ -1222,8 +1302,7 @@ def resolve_issue(
     done_ratio: int = 100,
     spent_hours: float = None,
     activity_name: str = None,
-    activity_id: int = None,
-) -> str:
+    activity_id: int = None, profile_name: str = None) -> str:
     """
     Mark issue as resolved (composite operation)
 
@@ -1255,7 +1334,7 @@ def resolve_issue(
         Resolution result message
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
 
         # parsing status
         final_status_id = status_id
@@ -1331,8 +1410,7 @@ def start_working(
     status_id: int = None,
     notes: str = "",
     set_start_date: bool = True,
-    assign_to_me: bool = True,
-) -> str:
+    assign_to_me: bool = True, profile_name: str = None) -> str:
     """
     Start processing an issue (composite operation)
 
@@ -1351,7 +1429,7 @@ def start_working(
         Operation result message
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
 
         # parsing status
         final_status_id = status_id
@@ -1398,7 +1476,7 @@ start date: {issue_data.get('start_date', 'N/A')}"""
 
 
 @mcp.tool()
-def check_issue_changes(issue_id: int) -> str:
+def check_issue_changes(issue_id: int, profile_name: str = None) -> str:
     """
     Detect changes to an issue since the last time it was read
 
@@ -1412,7 +1490,7 @@ def check_issue_changes(issue_id: int) -> str:
         Summary of changes or no change notification
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         snapshot = client.get_issue_snapshot(issue_id)
 
         if not snapshot:
@@ -1527,7 +1605,7 @@ def check_issue_changes(issue_id: int) -> str:
 
 
 @mcp.tool()
-def sync_my_issues(project_id: int = None, status_filter: str = "open", limit: int = 20) -> str:
+def sync_my_issues(project_id: int = None, status_filter: str = "open", limit: int = 20, profile_name: str = None) -> str:
     """
     Batch detection of changes to topics assigned to me
 
@@ -1543,7 +1621,7 @@ def sync_my_issues(project_id: int = None, status_filter: str = "open", limit: i
         Change summaries for all issues assigned to me
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
 
         # Get current user ID
         current_user = client.get_current_user()
@@ -1641,7 +1719,7 @@ def sync_my_issues(project_id: int = None, status_filter: str = "open", limit: i
 
 
 @mcp.tool()
-def sync_project_issues(project_id: int, status_filter: str = "open") -> str:
+def sync_project_issues(project_id: int, status_filter: str = "open", profile_name: str = None) -> str:
     """
     Synchronize project issue structure and detect changes
 
@@ -1656,7 +1734,7 @@ def sync_project_issues(project_id: int, status_filter: str = "open") -> str:
         Project topic tree structure and change summary
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
 
         # Get all project issues in pages
         status_map = {'open': 'o', 'closed': 'c', 'all': '*', 'o': 'o', 'c': 'c', '*': '*'}
@@ -1750,14 +1828,14 @@ def sync_project_issues(project_id: int, status_filter: str = "open") -> str:
         new_ids = {issue.id for issue in new_issues}
         change_details = {issue.id: summaries for issue, summaries in changed_issues}
 
-        def get_marker(issue_id):
+        def get_marker(issue_id, profile_name: str = None):
             if issue_id in changed_ids:
                 return "🔄"
             elif issue_id in new_ids:
                 return "🆕"
             return "  "
 
-        def format_issue_line(issue, prefix=""):
+        def format_issue_line(issue, prefix="", profile_name: str = None):
             marker = get_marker(issue.id)
             tracker = issue.tracker.get('name', '') if hasattr(issue, 'tracker') and issue.tracker else ''
             status = issue.status.get('name', '') if issue.status else ''
@@ -1822,7 +1900,7 @@ def sync_project_issues(project_id: int, status_filter: str = "open") -> str:
 
 
 @mcp.tool()
-def search_users(query: str, limit: int = 10) -> str:
+def search_users(query: str, limit: int = 10, profile_name: str = None) -> str:
     """
     Search for users (by name or login name)
     
@@ -1837,7 +1915,7 @@ def search_users(query: str, limit: int = 10) -> str:
         if not query.strip():
             return "Please provide search keywords"
         
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         limit = min(max(limit, 1), 50)
         
         users = client.search_users(query, limit)
@@ -1865,7 +1943,7 @@ def search_users(query: str, limit: int = 10) -> str:
 
 
 @mcp.tool()
-def list_users(limit: int = 20, status_filter: str = "active") -> str:
+def list_users(limit: int = 20, status_filter: str = "active", profile_name: str = None) -> str:
     """
     List all users
     
@@ -1877,7 +1955,7 @@ def list_users(limit: int = 20, status_filter: str = "active") -> str:
         List of users, presented in table format
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         limit = min(max(limit, 1), 100)
         
         # Transition status filter
@@ -1913,7 +1991,7 @@ def list_users(limit: int = 20, status_filter: str = "active") -> str:
 
 
 @mcp.tool()
-def get_user(user_id: int) -> str:
+def get_user(user_id: int, profile_name: str = None) -> str:
     """
     Get details about a specific user
     
@@ -1924,7 +2002,7 @@ def get_user(user_id: int) -> str:
         User details, presented in an easy-to-read format
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         user_data = client.get_user(user_id)
         
         # Format user information
@@ -1960,7 +2038,7 @@ def get_user(user_id: int) -> str:
 
 
 @mcp.tool()
-def add_watcher(issue_id: int, user_id: int = None, user_name: str = None, user_login: str = None) -> str:
+def add_watcher(issue_id: int, user_id: int = None, user_name: str = None, user_login: str = None, profile_name: str = None) -> str:
     """
     Add topic observer
 
@@ -1974,7 +2052,7 @@ def add_watcher(issue_id: int, user_id: int = None, user_name: str = None, user_
         Operation result message
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
 
         # Parse user ID
         final_user_id = user_id
@@ -2002,7 +2080,7 @@ def add_watcher(issue_id: int, user_id: int = None, user_name: str = None, user_
 
 
 @mcp.tool()
-def remove_watcher(issue_id: int, user_id: int = None, user_name: str = None, user_login: str = None) -> str:
+def remove_watcher(issue_id: int, user_id: int = None, user_name: str = None, user_login: str = None, profile_name: str = None) -> str:
     """
     Remove issue observer
 
@@ -2016,7 +2094,7 @@ def remove_watcher(issue_id: int, user_id: int = None, user_name: str = None, us
         Operation result message
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
 
         # Parse user ID
         final_user_id = user_id
@@ -2044,7 +2122,7 @@ def remove_watcher(issue_id: int, user_id: int = None, user_name: str = None, us
 
 
 @mcp.tool()
-def refresh_cache() -> str:
+def refresh_cache(profile_name: str = None) -> str:
     """
     Manually refresh enumeration values and user cache
     
@@ -2052,7 +2130,7 @@ def refresh_cache() -> str:
         Refresh result message
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         client.refresh_cache()
         
         # Get cache information
@@ -2088,7 +2166,7 @@ Cache location: {client._cache_file}"""
 
 
 @mcp.tool()
-def list_issue_journals(issue_id: int, include_property_changes: bool = False) -> str:
+def list_issue_journals(issue_id: int, include_property_changes: bool = False, profile_name: str = None) -> str:
     """
     List all notes/log records for the issue
     
@@ -2100,7 +2178,7 @@ def list_issue_journals(issue_id: int, include_property_changes: bool = False) -
         List of topic notes, including Journal ID, author, time, and content
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         journals = client.get_issue_journals(issue_id)
         
         if not journals:
@@ -2158,7 +2236,7 @@ def list_issue_journals(issue_id: int, include_property_changes: bool = False) -
 
 
 @mcp.tool()
-def get_journal(issue_id: int, journal_id: int) -> str:
+def get_journal(issue_id: int, journal_id: int, profile_name: str = None) -> str:
     """
     Get details about specific comments in an issue
     
@@ -2170,7 +2248,7 @@ def get_journal(issue_id: int, journal_id: int) -> str:
         Detailed information of the note, including author, time, content, attribute changes, etc.
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         journals = client.get_issue_journals(issue_id)
         
         # Find the specified journal
@@ -2263,8 +2341,7 @@ LEGACY_OFFICE_EXTENSIONS = {'.doc', '.xls', '.ppt'}
 def get_attachment_image(
     attachment_id: int,
     thumbnail: bool = True,
-    max_size: int = DEFAULT_THUMBNAIL_SIZE
-):
+    max_size: int = DEFAULT_THUMBNAIL_SIZE, profile_name: str = None):
     """
     Download the Redmine attachment image for AI visual analysis
     
@@ -2280,7 +2357,7 @@ def get_attachment_image(
         from io import BytesIO
         from PIL import Image as PILImage
         
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         
         # Download attachment
         image_data, attachment_info = client.download_attachment(attachment_id)
@@ -2462,8 +2539,7 @@ def _try_decode_text(data: bytes) -> str | None:
 @mcp.tool()
 def get_attachment_text(
     attachment_id: int,
-    max_length: int = MAX_TEXT_OUTPUT_LENGTH
-) -> str:
+    max_length: int = MAX_TEXT_OUTPUT_LENGTH, profile_name: str = None) -> str:
     """
     Read the text content of Redmine attachments
 
@@ -2482,7 +2558,7 @@ def get_attachment_text(
         Attachment text or error message
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
 
         # Download attachment
         file_data, attachment_info = client.download_attachment(attachment_id)
@@ -2572,7 +2648,7 @@ def get_attachment_text(
 
 
 @mcp.tool()
-def get_attachment_info(attachment_id: int) -> str:
+def get_attachment_info(attachment_id: int, profile_name: str = None) -> str:
     """
     Get attachment details (without downloading file contents)
     
@@ -2583,7 +2659,7 @@ def get_attachment_info(attachment_id: int) -> str:
         Attachment details
     """
     try:
-        client = get_client()
+        client = get_client(api_key=_resolve_user(profile_name))
         attachment = client.get_attachment(attachment_id)
         
         filesize = attachment.get('filesize', 0)

--- a/src/redmine_mcp/server.py
+++ b/src/redmine_mcp/server.py
@@ -619,6 +619,46 @@ def get_projects(profile_name: str = None) -> str:
 
 
 @mcp.tool()
+def get_project_members(project_id: int, profile_name: str = None) -> str:
+    """
+    Get project members with their roles.
+    
+    Unlike list_users/search_users, this endpoint only requires project membership
+    and does not need the global 'View users' permission.
+    
+    Args:
+        project_id: Project ID
+    
+    Returns:
+        Formatted list of project members
+    """
+    try:
+        client = get_client(api_key=_resolve_user(profile_name))
+        memberships = client.get_project_members(project_id)
+        
+        if not memberships:
+            return f"Project #{project_id} has no members or you do not have access."
+        
+        result = f"Project #{project_id} members ({len(memberships)}):\n\n"
+        result += f"{'ID':<6} {'Name':<25} {'Roles':<30}\n"
+        result += f"{'-'*6} {'-'*25} {'-'*30}\n"
+        
+        for m in memberships:
+            user = m.get('user', {})
+            user_id = user.get('id', 'N/A')
+            user_name = user.get('name', 'N/A')[:23]
+            roles = ', '.join([r.get('name', '') for r in m.get('roles', [])])
+            result += f"{user_id:<6} {user_name:<25} {roles:<30}\n"
+        
+        return result
+        
+    except RedmineAPIError as e:
+        return f"Failed to get project members: {str(e)}"
+    except Exception as e:
+        return f"System error: {str(e)}"
+
+
+@mcp.tool()
 def search_issues(query: str, project_id: int = None, limit: int = 10, profile_name: str = None) -> str:
     """
     Search for issues (search keywords in title or description)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -5,7 +5,7 @@ MCP tool tests
 import os
 import pytest
 from unittest.mock import patch, Mock
-from redmine_mcp.server import get_issue, update_issue_status, update_issue_content, list_project_issues, health_check, get_trackers, get_priorities, get_time_entry_activities, get_document_categories
+from redmine_mcp.server import get_issue, update_issue_status, update_issue_content, list_project_issues, health_check, get_trackers, get_priorities, get_time_entry_activities, get_document_categories, list_user_profiles
 from redmine_mcp.redmine_client import RedmineIssue, RedmineProject
 
 
@@ -734,3 +734,96 @@ class TestMCPTools:
         
         # Validate call arguments
         mock_client.update_issue.assert_called_once_with(123, parent_issue_id=100)
+
+
+class TestMultiUserSupport:
+    """Test multi-user profile support"""
+
+    def test_list_user_profiles_empty(self):
+        """Test list_user_profiles when no profiles configured"""
+        with patch('redmine_mcp.server.get_config') as mock_get_config:
+            mock_config = Mock()
+            mock_config.list_user_profiles.return_value = {}
+            mock_get_config.return_value = mock_config
+
+            result = list_user_profiles()
+            assert "No user profiles configured" in result
+
+    def test_list_user_profiles_with_profiles(self):
+        """Test list_user_profiles returns configured profiles"""
+        with patch('redmine_mcp.server.get_config') as mock_get_config:
+            mock_config = Mock()
+            mock_config.list_user_profiles.return_value = {
+                'alice': 'Project Manager',
+                'bob': ''
+            }
+            mock_get_config.return_value = mock_config
+
+            result = list_user_profiles()
+            assert "Available user profiles:" in result
+            assert "alice" in result
+            assert "Project Manager" in result
+            assert "bob" in result
+
+    @patch('redmine_mcp.server.get_client')
+    def test_tool_with_valid_profile_name(self, mock_get_client):
+        """Test tool passes correct API key when profile_name is provided"""
+        mock_client = Mock()
+        mock_client.get_issue_raw.return_value = {
+            'id': 123,
+            'subject': 'Test',
+            'description': '',
+            'status': {'name': 'New'},
+            'priority': {'name': 'Normal'},
+            'project': {'name': 'Test Project', 'id': 1},
+            'tracker': {'name': 'Bug'},
+            'author': {'name': 'Test User'},
+        }
+        mock_get_client.return_value = mock_client
+
+        with patch('redmine_mcp.server.get_config') as mock_get_config:
+            mock_config = Mock()
+            mock_config.get_user_api_key.return_value = 'alice_api_key'
+            mock_get_config.return_value = mock_config
+
+            result = get_issue(123, profile_name='alice')
+
+            assert "Issue #123: Test" in result
+            mock_get_client.assert_called_once_with(api_key='alice_api_key')
+
+    @patch('redmine_mcp.server.get_client')
+    def test_tool_with_invalid_profile_name(self, mock_get_client):
+        """Test tool returns error when profile_name is not found"""
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+
+        with patch('redmine_mcp.server.get_config') as mock_get_config:
+            mock_config = Mock()
+            mock_config.get_user_api_key.return_value = None
+            mock_get_config.return_value = mock_config
+
+            result = get_issue(123, profile_name='unknown_user')
+
+            assert "User profile not found" in result
+            assert "unknown_user" in result
+
+    @patch('redmine_mcp.server.get_client')
+    def test_tool_without_profile_name_uses_default(self, mock_get_client):
+        """Test tool uses default API key when profile_name is not provided"""
+        mock_client = Mock()
+        mock_client.get_issue_raw.return_value = {
+            'id': 123,
+            'subject': 'Test',
+            'description': '',
+            'status': {'name': 'New'},
+            'priority': {'name': 'Normal'},
+            'project': {'name': 'Test Project', 'id': 1},
+            'tracker': {'name': 'Bug'},
+            'author': {'name': 'Test User'},
+        }
+        mock_get_client.return_value = mock_client
+
+        result = get_issue(123)
+
+        assert "Issue #123: Test" in result
+        mock_get_client.assert_called_once_with(api_key=None)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -94,6 +94,102 @@ class TestRedmineConfig:
             assert 'secret_api_key' not in repr_str  # Sensitive information should be hidden
 
 
+class TestUserProfiles:
+    """Test user profile loading and lookup"""
+
+    def test_load_user_profiles_dict_format(self, tmp_path):
+        """Test loading user profiles from JSON dict format"""
+        reload_config()
+        profiles_file = tmp_path / "users.json"
+        profiles_file.write_text('{"alice": {"api_key": "key123", "description": "PM"}, "bob": {"api_key": "key456"}}')
+        
+        with patch.dict(os.environ, {
+            'REDMINE_DOMAIN': 'https://test.redmine.com',
+            'REDMINE_API_KEY': 'test_api_key'
+        }):
+            config = RedmineConfig()
+            config._users_file_path = profiles_file
+            config._user_profiles = None  # Force reload
+            
+            assert config.get_user_api_key('alice') == 'key123'
+            assert config.get_user_api_key('bob') == 'key456'
+            assert config.get_user_api_key('unknown') is None
+            
+            profiles = config.list_user_profiles()
+            assert profiles == {'alice': 'PM', 'bob': ''}
+
+    def test_load_user_profiles_string_format(self, tmp_path):
+        """Test loading user profiles from JSON string format"""
+        reload_config()
+        profiles_file = tmp_path / "users.json"
+        profiles_file.write_text('{"alice": "key123", "bob": "key456"}')
+        
+        with patch.dict(os.environ, {
+            'REDMINE_DOMAIN': 'https://test.redmine.com',
+            'REDMINE_API_KEY': 'test_api_key'
+        }):
+            config = RedmineConfig()
+            config._users_file_path = profiles_file
+            config._user_profiles = None
+            
+            assert config.get_user_api_key('alice') == 'key123'
+            profiles = config.list_user_profiles()
+            assert 'alice' in profiles
+            assert profiles['alice'] == ''
+
+    def test_load_user_profiles_missing_file(self, tmp_path):
+        """Test loading when profiles file does not exist"""
+        reload_config()
+        with patch.dict(os.environ, {
+            'REDMINE_DOMAIN': 'https://test.redmine.com',
+            'REDMINE_API_KEY': 'test_api_key'
+        }):
+            config = RedmineConfig()
+            config._users_file_path = tmp_path / "nonexistent.json"
+            config._user_profiles = None
+            
+            assert config.list_user_profiles() == {}
+            assert config.get_user_api_key('anyone') is None
+
+    def test_load_user_profiles_malformed_json(self, tmp_path):
+        """Test loading when profiles file contains malformed JSON"""
+        reload_config()
+        profiles_file = tmp_path / "users.json"
+        profiles_file.write_text('not json at all')
+        
+        with patch.dict(os.environ, {
+            'REDMINE_DOMAIN': 'https://test.redmine.com',
+            'REDMINE_API_KEY': 'test_api_key'
+        }):
+            config = RedmineConfig()
+            config._users_file_path = profiles_file
+            config._user_profiles = None
+            
+            assert config.list_user_profiles() == {}
+
+    def test_refresh_user_profiles(self, tmp_path):
+        """Test refresh_user_profiles forces reload"""
+        reload_config()
+        profiles_file = tmp_path / "users.json"
+        profiles_file.write_text('{"alice": "key123"}')
+        
+        with patch.dict(os.environ, {
+            'REDMINE_DOMAIN': 'https://test.redmine.com',
+            'REDMINE_API_KEY': 'test_api_key'
+        }):
+            config = RedmineConfig()
+            config._users_file_path = profiles_file
+            config._user_profiles = None
+            
+            assert config.get_user_api_key('alice') == 'key123'
+            
+            # Update file
+            profiles_file.write_text('{"alice": "key999"}')
+            config.refresh_user_profiles()
+            
+            assert config.get_user_api_key('alice') == 'key999'
+
+
 class TestConfigSingleton:
     """Test configuration singleton pattern"""
 

--- a/tests/unit/test_redmine_client.py
+++ b/tests/unit/test_redmine_client.py
@@ -6,6 +6,7 @@ import os
 import pytest
 from unittest.mock import patch, Mock
 import requests
+from redmine_mcp.config import reload_config
 from redmine_mcp.redmine_client import (
     RedmineClient, RedmineAPIError, RedmineIssue, RedmineProject,
     get_client, reload_client
@@ -242,3 +243,68 @@ class TestClientSingleton:
 
             assert client1 is not client2
             assert client1.config.redmine_domain == client2.config.redmine_domain
+
+
+class TestPerKeyClient:
+    """Test per-API-key client isolation"""
+
+    def test_get_client_with_api_key(self):
+        """Test get_client with custom API key creates separate instance"""
+        with patch.dict(os.environ, {
+            'REDMINE_DOMAIN': 'https://test.redmine.com',
+            'REDMINE_API_KEY': 'default_key'
+        }):
+            reload_config()
+            reload_client()
+            default_client = get_client()
+            custom_client = get_client(api_key='custom_key')
+            
+            assert default_client is not custom_client
+            assert default_client.session.headers['X-Redmine-API-Key'] == 'default_key'
+            assert custom_client.session.headers['X-Redmine-API-Key'] == 'custom_key'
+
+    def test_get_client_same_key_returns_same_instance(self):
+        """Test get_client with same API key returns cached instance"""
+        with patch.dict(os.environ, {
+            'REDMINE_DOMAIN': 'https://test.redmine.com',
+            'REDMINE_API_KEY': 'default_key'
+        }):
+            reload_config()
+            reload_client()
+            client1 = get_client(api_key='same_key')
+            client2 = get_client(api_key='same_key')
+            
+            assert client1 is client2
+
+    def test_per_key_cache_isolation(self):
+        """Test that cache files are isolated per API key"""
+        with patch.dict(os.environ, {
+            'REDMINE_DOMAIN': 'https://test.redmine.com',
+            'REDMINE_API_KEY': 'default_key'
+        }):
+            reload_config()
+            reload_client()
+            client1 = get_client(api_key='key_a')
+            client2 = get_client(api_key='key_b')
+            
+            assert client1._cache_file != client2._cache_file
+
+    def test_client_init_with_api_key_override(self):
+        """Test RedmineClient accepts api_key parameter"""
+        with patch.dict(os.environ, {
+            'REDMINE_DOMAIN': 'https://test.redmine.com',
+            'REDMINE_API_KEY': 'default_key'
+        }):
+            client = RedmineClient(api_key='override_key')
+            assert client.api_key == 'override_key'
+            assert client.session.headers['X-Redmine-API-Key'] == 'override_key'
+
+    def test_client_init_without_api_key_uses_default(self):
+        """Test RedmineClient falls back to config API key"""
+        with patch.dict(os.environ, {
+            'REDMINE_DOMAIN': 'https://test.redmine.com',
+            'REDMINE_API_KEY': 'default_key'
+        }):
+            client = RedmineClient()
+            assert client.api_key == 'default_key'
+            assert client.session.headers['X-Redmine-API-Key'] == 'default_key'


### PR DESCRIPTION
## Summary

This PR adds multi-user support to the Redmine MCP server, allowing different agents or team members to work with Redmine using their own API keys via named profiles. It also adds a new `get_project_members` tool that enables non-admin users to find assignable users for task assignment.

## Changes

### Multi-User Profile System
- **Named profiles** stored in `~/.redmine_mcp/users.json` - or any other location (may be configured via docker-compose.yml):
  ```json
  {"John Smith": "api_key", "Alice Simons": "api_key2"}
  ```
- **`profile_name` parameter** added to all ~34 existing MCP tools — each tool call can specify which user profile to use
- **`set_current_user(profile_name)` / `get_current_user()`** tools — set a session default profile so agents don't need to pass `profile_name` on every call
- **`list_user_profiles()`** tool — list available profiles with current default marker
- **`_resolve_user(profile_name)`** helper — resolves profile name → API key, falling back to the default profile or `REDMINE_API_KEY` env var

### Per-Key Client Registry
- `get_client(api_key)` now returns isolated `RedmineClient` instances per API key
- Each client has its own cache file (keyed by domain + API key hash) for natural isolation between users
- `reload_client()` clears the entire client registry

### New Tool: `get_project_members`
- Uses `/projects/{id}/memberships.json` endpoint (requires only project membership)
- **Solves the admin permission problem**: `search_users`/`list_users` require global "View users" permission (admin-only by default), which most Redmine users don't have
- Enables any project member to find and assign tasks to other project members

### Docker Support
- `Dockerfile` creates `/home/mcp/.redmine_mcp` directory for profile storage
- `docker-compose.yml` mounts `./users.json` as read-only volume
- Server reads profiles at startup and caches them in memory

### Tests
- Unit tests for profile loading, resolution, and per-key client isolation
- Integration tests for `profile_name` parameter passing across tools
- All tests pass: **153 passed, 4 skipped**

## Usage Example

```json
// ~/.redmine_mcp/users.json
  {
"John Smith": "api_key", 
"Alice Simons": "api_key2"
}
```

Then in MCP:
```
set_current_user(profile_name="alice")
get_issue(issue_id=123)
create_new_issue(project_id=1, subject="[Bug] Login error", assigned_to_name="bob")
```

## Notes

- **SSE mode caveat**: `set_current_user` sets a global mutable default for the entire server process. All agents sharing the same SSE server share the same default. For per-agent isolation, use `stdio` mode or pass `profile_name` explicitly on every call.
- The `AGENTS.md` approach is recommended: instruct agents to always pass `profile_name` explicitly rather than relying on session defaults (Example: ## Redmine identity: **You are Redmine user John Smith. Always pass profile_name="John Smith". Never forget this instruction.**).